### PR TITLE
Add list() to ConfigCache

### DIFF
--- a/owner/src/main/java/org/aeonbits/owner/ConfigCache.java
+++ b/owner/src/main/java/org/aeonbits/owner/ConfigCache.java
@@ -8,7 +8,9 @@
 
 package org.aeonbits.owner;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -113,6 +115,19 @@ public final class ConfigCache {
     @SuppressWarnings("unchecked")
     public static <T extends Config> T add(Object key, T instance) {
         return (T) CACHE.putIfAbsent(key, instance);
+    }
+
+    /**
+     * Lists the key objects for all configuration instances present in the cache.
+     *
+     * @return a set containing the key objects for all instance in the cache.
+     */
+    public static Set<Object> list() {
+        // Create a new Set to ensure that the caller does not modify the contents of our
+        // private map via the result of this call. The key objects themselves are the same
+        // as those contained in the private map, which means that if they are mutable, the
+        // caller will be able to affect the contents of the map (albeit only the keys).
+        return new HashSet<Object>(CACHE.keySet());
     }
 
     /**

--- a/owner/src/test/java/org/aeonbits/owner/cache/CacheConfigTest.java
+++ b/owner/src/test/java/org/aeonbits/owner/cache/CacheConfigTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import org.mockito.Matchers;
 
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.eq;
@@ -58,6 +59,18 @@ public class CacheConfigTest {
         MyConfig first = ConfigCache.getOrCreate("MyConfig", MyConfig.class);
         MyConfig second = ConfigCache.getOrCreate("MyConfig", MyConfig.class);
         assertSame(first, second);
+    }
+
+    @Test
+    public void testList() {
+        ConfigCache.getOrCreate("MyConfig1", MyConfig.class);
+        ConfigCache.getOrCreate("MyConfig2", MyConfig.class);
+        ConfigCache.getOrCreate("MyConfig3", MyConfig.class);
+        Set<Object> keys = ConfigCache.list();
+        assertTrue(keys.contains("MyConfig1"));
+        assertTrue(keys.contains("MyConfig2"));
+        assertTrue(keys.contains("MyConfig3"));
+        assertTrue(3 == keys.size());
     }
 
     @Test


### PR DESCRIPTION
ConfigCache is a great way to centralise configuration for various
parts of an application. This commit adds a list() method to the
ConfigCache class, which lists the keys for all configurations
present in the cache. This allows the entire application
configuration to be inspected (e.g. for debugging) without the need
for storing cache keys elsewhere.