### PR TITLE
Fixes to ensure tests run on Windows

### DIFF
--- a/owner/src/main/java/org/aeonbits/owner/Util.java
+++ b/owner/src/main/java/org/aeonbits/owner/Util.java
@@ -166,7 +166,13 @@ abstract class Util {
     }
 
     static File fileFromURI(String uriSpec) throws URISyntaxException {
-        return fileFromURI(new URI(uriSpec));
+        try {
+            return fileFromURI(new URI(uriSpec));
+        } catch (URISyntaxException e) {
+            // Perhaps the path contains backslashes
+            uriSpec = uriSpec.replace('\\', '/');
+            return fileFromURI(new URI(uriSpec));
+        }
     }
 
     static boolean eq(Object o1, Object o2) {

--- a/owner/src/test/java/org/aeonbits/owner/loadstrategies/LoadStrategyTestBase.java
+++ b/owner/src/test/java/org/aeonbits/owner/loadstrategies/LoadStrategyTestBase.java
@@ -24,7 +24,7 @@ public class LoadStrategyTestBase {
 
             public boolean matches(Object o) {
                 uri = (URI)o;
-                return uri.getPath().endsWith(path);
+                return uri.toString().endsWith(path);
             }
 
             public void describeTo(Description description) {


### PR DESCRIPTION
Running tests on Windows platforms currently fails due to the
assumption that filesystem paths can be directly used in URIs.
This is true on *nix platforms, but not on Windows.