### PR TITLE
Add support for deserializing nested JSON documents (using google gson)

### DIFF
--- a/owner-extras/pom.xml
+++ b/owner-extras/pom.xml
@@ -39,6 +39,14 @@
             <optional>true</optional>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.5</version>
+            <optional>true</optional>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/owner-extras/src/main/java/org/aeonbits/owner/loaders/JSONLoader.java
+++ b/owner-extras/src/main/java/org/aeonbits/owner/loaders/JSONLoader.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
+ * All rights reserved.
+ *
+ * This software is distributable under the BSD license.
+ * See the terms of the BSD license in the documentation provided with this software.
+ */
+
+package org.aeonbits.owner.loaders;
+
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.Properties;
+import java.util.Stack;
+
+/**
+ * A {@link Loader loader} that can read properties from a JSON file.
+ *
+ * @author Ketan Padegaonkar
+ * @since 1.0.10
+ */
+public class JSONLoader implements Loader {
+
+    public boolean accept(URI uri) {
+        try {
+            URL url = uri.toURL();
+            return url.getFile().toLowerCase().endsWith(".json");
+        } catch (MalformedURLException ex) {
+            return false;
+        }
+    }
+
+    public void load(Properties result, URI uri) throws IOException {
+        URL url = uri.toURL();
+        InputStream input = url.openStream();
+        try {
+            load(result, input);
+        } finally {
+            input.close();
+        }
+    }
+
+    void load(Properties result, InputStream input) throws IOException {
+        new JsonToPropsHandler(result).parse(input);
+    }
+
+    public String defaultSpecFor(String urlPrefix) {
+        return urlPrefix + ".json";
+    }
+
+    class JsonToPropsHandler {
+        private final Properties props;
+        private final Stack<String> paths = new Stack<String>();
+        private final Stack<StringBuilder> value = new Stack<StringBuilder>();
+
+        JsonToPropsHandler(Properties props) {
+            this.props = props;
+        }
+
+        public void parse(InputStream input) throws IOException {
+            parse(new JsonReader(new InputStreamReader(input, "UTF-8")));
+        }
+
+        private void parse(JsonReader reader) throws IOException {
+            while (reader.hasNext()) {
+                JsonToken token = reader.peek();
+                switch (token) {
+                    case BEGIN_OBJECT:
+                        reader.beginObject();
+                        parse(reader);
+                        reader.endObject();
+                        if (!value.isEmpty())
+                            value.pop();
+                        if (!paths.isEmpty())
+                            paths.pop();
+                        break;
+                    case BEGIN_ARRAY:
+                        value.push(new StringBuilder());
+                        reader.beginArray();
+
+                        while (reader.hasNext()) {
+                            JsonToken arrayElementToken = reader.peek();
+                            switch (arrayElementToken) {
+                                case STRING:
+                                    value.peek().append(reader.nextString());
+                                    break;
+                                case NUMBER:
+                                    value.peek().append(reader.nextInt());
+                                    break;
+                                case BOOLEAN:
+                                    value.peek().append(reader.nextBoolean());
+                                    break;
+                                case NULL:
+                                    reader.nextNull();
+                                    value.peek().append((String) null);
+                            }
+
+                            if (reader.hasNext()) {
+                                value.peek().append(", ");
+                            }
+                        }
+                        reader.endArray();
+                        endObject();
+                        break;
+                    case NAME:
+                        String name = reader.nextName();
+                        String path = (paths.size() == 0) ? name : paths.peek() + "." + name;
+                        paths.push(path);
+                        break;
+                    case STRING:
+                        value.push(new StringBuilder());
+                        value.peek().append(reader.nextString());
+                        endObject();
+                        break;
+                    case NUMBER:
+                        value.push(new StringBuilder());
+                        value.peek().append(reader.nextInt());
+                        endObject();
+                        break;
+                    case BOOLEAN:
+                        value.push(new StringBuilder());
+                        value.peek().append(reader.nextBoolean());
+                        endObject();
+                        break;
+                    case NULL:
+                        value.push(new StringBuilder());
+                        reader.nextNull();
+                        value.peek().append((String) null);
+                        endObject();
+                        break;
+                    case END_DOCUMENT:
+                        reader.close();
+                        return;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        private void endObject() {
+            String key = paths.peek();
+            String propertyValue = this.value.peek().toString().trim();
+            if (!propertyValue.isEmpty())
+                props.setProperty(key, propertyValue);
+            value.pop();
+            paths.pop();
+        }
+    }
+}

--- a/owner-extras/src/test/java/org/aeonbits/owner/loaders/JSONLoaderTest.java
+++ b/owner-extras/src/test/java/org/aeonbits/owner/loaders/JSONLoaderTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 ThoughtWorks, Inc.
+ * All rights reserved.
+ *
+ * This software is distributable under the BSD license.
+ * See the terms of the BSD license in the documentation provided with this software.
+ */
+
+package org.aeonbits.owner.loaders;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+public class JSONLoaderTest {
+
+    @Test
+    public void testJSONReading() throws IOException {
+        JSONLoader loader = new JSONLoader();
+        Properties props = new Properties();
+        loader.load(props, getClass().getClassLoader().getResourceAsStream("org/aeonbits/owner/server.test.json"));
+
+        assertEquals(7, props.size());
+        assertEquals("80", props.getProperty("server.http.port"));
+        assertEquals("localhost", props.getProperty("server.http.hostname"));
+        assertEquals("22", props.getProperty("server.ssh.port"));
+        assertEquals("127.0.0.1", props.getProperty("server.ssh.address"));
+        assertEquals("60", props.getProperty("server.ssh.alive.interval"));
+        assertEquals("admin", props.getProperty("server.ssh.user"));
+        assertEquals("bob, alice", props.getProperty("server.admins"));
+    }
+}

--- a/owner-extras/src/test/resources/org/aeonbits/owner/server.test.json
+++ b/owner-extras/src/test/resources/org/aeonbits/owner/server.test.json
@@ -1,0 +1,20 @@
+{
+  "server": {
+    "http": {
+      "port": 80,
+      "hostname": "localhost"
+    },
+    "ssh": {
+      "port": 22,
+      "address": "127.0.0.1",
+      "alive": {
+        "interval": 60
+      },
+      "user": "admin"
+    },
+    "admins": [
+      "bob",
+      "alice"
+    ]
+  }
+}


### PR DESCRIPTION
For developers not wanting to use json, and to keep the dependency foot-print
at a minimum, the gson dependency is set to "provided".

The `LoadersManager` will check if Google's Gson parser is available on
path before attempting to register the JSON parser. (I'm happy to change this
behavior if you feel there's a better way to do this)

Usage -

``` json
{
  "server": {
    "http": {
      "port": 80,
      "hostname": "localhost"
    },
    "ssh": {
      "port": 22,
      "address": "127.0.0.1",
      "alive": {
        "interval": 60
      },
      "user": "admin"
    },
    "admins": ["bob", "alice"]
  }
}
```

``` java
@Config.Sources({"classpath:org/aeonbits/owner/server.test.json"})
public static interface ServerConfig extends Config, Accessible {

    @Key("server.http.port")
    int httpPort();

    @Key("server.http.hostname")
    String httpHostname();

    @Key("server.ssh.port")
    int sshPort();

    @Key("server.ssh.address")
    String sshAddress();

    @Key("server.ssh.alive.interval")
    int aliveInterval();

    @Key("server.ssh.user")
    String sshUser();

    @Key("server.admins")
    List<String> admins();
}
```
