### PR TITLE
Added a Java 8 duration converter

### DIFF
--- a/owner-java8/src/main/java/org/aeonbits/owner/converters/DurationConverter.java
+++ b/owner-java8/src/main/java/org/aeonbits/owner/converters/DurationConverter.java
@@ -31,7 +31,7 @@ import java.time.temporal.ChronoUnit;
  *             <li>d / days</li>
  *         </ul>
  *         Note that the <code>time_unit</code> string is case sensitive.
- *         <br/>
+ *         <p>
  *         If no <code>time_unit</code> is specified, <code>milliseconds</code> is assumed.
  *     </li>
  * </ul>

--- a/owner-java8/src/main/java/org/aeonbits/owner/converters/DurationConverter.java
+++ b/owner-java8/src/main/java/org/aeonbits/owner/converters/DurationConverter.java
@@ -1,0 +1,136 @@
+package org.aeonbits.owner.converters;
+
+import org.aeonbits.owner.Converter;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * A duration converter for the OWNER configuration system.
+ *
+ * This converter will convert various duration formatted strings over to {@link java.time.Duration} objects.
+ *
+ * The class supports two formats for the duration string:
+ * <ul>
+ *     <li>
+ *         The ISO-8601 based format that the {@link java.time.Duration#parse(CharSequence)} method supports.
+ *         The implementation will check whether the input string starts with <code>P</code> with an optional plus/minus
+ *         prefix and if so, will use this method for parsing.
+ *     </li>
+ *     <li>
+ *         A "<code>value time_unit</code>" string where the <code>value</code> is an integer and <code>time_unit</code>
+ *         is one of:
+ *         <ul>
+ *             <li>ns / nanos / nanoseconds</li>
+ *             <li>us / µs / micros / microseconds</li>
+ *             <li>ms / millis / milliseconds</li>
+ *             <li>s / seconds</li>
+ *             <li>m / minutes</li>
+ *             <li>h / hours</li>
+ *             <li>d / days</li>
+ *         </ul>
+ *         Note that the <code>time_unit</code> string is case sensitive.
+ *         <br/>
+ *         If no <code>time_unit</code> is specified, <code>milliseconds</code> is assumed.
+ *     </li>
+ * </ul>
+ */
+public class DurationConverter implements Converter<Duration> {
+
+    @Override
+    public Duration convert(Method method, String input) {
+        // If it looks like a string that Duration.parse can handle, let's try that.
+        if (input.startsWith("P") || input.startsWith("-P") || input.startsWith("+P")) {
+            return Duration.parse(input);
+        }
+        // ...otherwise we'll perform our own parsing
+        return parseDuration(input);
+    }
+
+    /**
+     * Parses a duration string. If no units are specified in the string, it is
+     * assumed to be in milliseconds.
+     *
+     * This implementation was blatantly stolen/adapted from the typesafe-config project:
+     * https://github.com/typesafehub/config/blob/v1.3.0/config/src/main/java/com/typesafe/config/impl/SimpleConfig.java#L551-L624
+     *
+     * @param input the string to parse
+     * @return duration
+     * @throws IllegalArgumentException if input is invalid
+     */
+    private static Duration parseDuration(String input) {
+        // ATTN: String.trim() may not trim all UTF-8 whitespace characters properly.
+        // The original implementation used its own unicodeTrim() method that I decided not to copy over until
+        // the need arises.
+        // For more information, see:
+        // https://github.com/typesafehub/config/blob/v1.3.0/config/src/main/java/com/typesafe/config/impl/ConfigImplUtil.java#L118-L164
+
+        String s = input.trim();
+        String originalUnitString = getUnits(s);
+        String unitString = originalUnitString;
+        String numberString = s.substring(0, s.length() - unitString.length()).trim();
+
+        if (numberString.length() == 0) {
+            throw new IllegalArgumentException(String.format("No number in duration value '%s'", input));
+        }
+
+        if (unitString.length() > 2 && !unitString.endsWith("s")) {
+            unitString = unitString + "s";
+        }
+
+        ChronoUnit units;
+        // note that this is deliberately case-sensitive
+        switch (unitString) {
+            case "ns":
+            case "nanos":
+            case "nanoseconds":
+                units = ChronoUnit.NANOS;
+                break;
+            case "us":
+            case "µs":
+            case "micros":
+            case "microseconds":
+                units = ChronoUnit.MICROS;
+                break;
+            case "":
+            case "ms":
+            case "millis":
+            case "milliseconds":
+                units = ChronoUnit.MILLIS;
+                break;
+            case "s":
+            case "seconds":
+                units = ChronoUnit.SECONDS;
+                break;
+            case "m":
+            case "minutes":
+                units = ChronoUnit.MINUTES;
+                break;
+            case "h":
+            case "hours":
+                units = ChronoUnit.HOURS;
+                break;
+            case "d":
+            case "days":
+                units = ChronoUnit.DAYS;
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        String.format("Could not parse time unit '%s' (try ns, us, ms, s, m, h, d)", originalUnitString));
+        }
+
+        return Duration.of(Long.parseLong(numberString), units);
+    }
+
+    private static String getUnits(String s) {
+        int i = s.length() - 1;
+        while (i >= 0) {
+            char c = s.charAt(i);
+            if (!Character.isLetter(c))
+                break;
+            i -= 1;
+        }
+        return s.substring(i + 1);
+    }
+}

--- a/owner-java8/src/main/java/org/aeonbits/owner/converters/DurationConverter.java
+++ b/owner-java8/src/main/java/org/aeonbits/owner/converters/DurationConverter.java
@@ -14,7 +14,10 @@ import java.time.temporal.ChronoUnit;
  * The class supports two formats for the duration string:
  * <ul>
  *     <li>
- *         The ISO-8601 based format that the {@link java.time.Duration#parse(CharSequence)} method supports.
+ *         The ISO-8601 based format that the {@link java.time.Duration#parse(CharSequence)} method supports
+ *         (<a href="https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-"
+ *         target="_blank">see the official Java 8 documentation</a>, although note that currently there is an
+ *         <a href="https://bugs.openjdk.java.net/browse/JDK-8146173" target="_blank">error in the documentation</a>).
  *         The implementation will check whether the input string starts with <code>P</code> with an optional plus/minus
  *         prefix and if so, will use this method for parsing.
  *     </li>
@@ -30,6 +33,7 @@ import java.time.temporal.ChronoUnit;
  *             <li>h / hours</li>
  *             <li>d / days</li>
  *         </ul>
+ *         <p>
  *         Note that the <code>time_unit</code> string is case sensitive.
  *         <p>
  *         If no <code>time_unit</code> is specified, <code>milliseconds</code> is assumed.

--- a/owner-java8/src/test/java/org/aeonbits/owner/typeconversion/DurationTypesTest.java
+++ b/owner-java8/src/test/java/org/aeonbits/owner/typeconversion/DurationTypesTest.java
@@ -1,0 +1,195 @@
+package org.aeonbits.owner.typeconversion;
+
+import org.aeonbits.owner.Config;
+import org.aeonbits.owner.ConfigFactory;
+import org.aeonbits.owner.converters.DurationConverter;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+public class DurationTypesTest {
+
+    public interface DurationTypesConfig extends Config {
+        // empty suffix
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10")
+        Duration emptySuffix();
+
+        // no space before suffix
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10ms")
+        Duration noSpaceBeforeSuffix();
+
+        // nanoseconds
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 ns")
+        Duration nsSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 nano")
+        Duration nanoSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 nanos")
+        Duration nanosSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 nanosecond")
+        Duration nanosecondSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 nanoseconds")
+        Duration nanosecondsSuffix();
+
+        // microseconds
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 us")
+        Duration usSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 µs")
+        Duration µsSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 micro")
+        Duration microSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 micros")
+        Duration microsSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 microsecond")
+        Duration microsecondSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 microseconds")
+        Duration microsecondsSuffix();
+
+        // milliseconds
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 ms")
+        Duration msSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 milli")
+        Duration milliSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 millis")
+        Duration millisSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 millisecond")
+        Duration millisecondSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 milliseconds")
+        Duration millisecondsSuffix();
+
+        // seconds
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 s")
+        Duration sSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 second")
+        Duration secondSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 seconds")
+        Duration secondsSuffix();
+
+        // minutes
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 m")
+        Duration mSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 minute")
+        Duration minuteSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 minutes")
+        Duration minutesSuffix();
+
+        // hours
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 h")
+        Duration hSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 hour")
+        Duration hourSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 hours")
+        Duration hoursSuffix();
+
+        // days
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 d")
+        Duration dSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 day")
+        Duration daySuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("10 days")
+        Duration daysSuffix();
+    }
+
+    private static boolean allEqual(Duration compareTo, Collection<Duration> durations){
+        for (Duration duration : durations) {
+            if( !compareTo.equals(duration) ){
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Test
+    public void testEmptySuffix() {
+        DurationTypesConfig cfg = ConfigFactory.create(DurationTypesConfig.class);
+        assertEquals(Duration.of(10, ChronoUnit.MILLIS), cfg.emptySuffix());
+    }
+
+    @Test
+    public void testNoSpaceBeforeSuffix() {
+        DurationTypesConfig cfg = ConfigFactory.create(DurationTypesConfig.class);
+        assertEquals(Duration.of(10, ChronoUnit.MILLIS), cfg.noSpaceBeforeSuffix());
+    }
+
+    @Test
+    public void testSuffixEquality() {
+        DurationTypesConfig cfg = ConfigFactory.create(DurationTypesConfig.class);
+
+        allEqual(Duration.of(10, ChronoUnit.NANOS),
+                Arrays.asList(cfg.nsSuffix(),cfg.nanoSuffix(),cfg.nanosSuffix(),cfg.nanosecondSuffix(),cfg.nanosecondsSuffix()));
+
+        allEqual(Duration.of(10, ChronoUnit.MICROS),
+                Arrays.asList(cfg.usSuffix(),cfg.µsSuffix(),cfg.microSuffix(),cfg.microsSuffix(),cfg.microsecondSuffix(),cfg.microsecondsSuffix()));
+
+        allEqual(Duration.of(10, ChronoUnit.MILLIS),
+                Arrays.asList(cfg.msSuffix(),cfg.milliSuffix(),cfg.millisSuffix(),cfg.millisecondSuffix(),cfg.millisecondsSuffix()));
+
+        allEqual(Duration.of(10, ChronoUnit.SECONDS),
+                Arrays.asList(cfg.sSuffix(),cfg.secondSuffix(),cfg.secondsSuffix()));
+
+        allEqual(Duration.of(10, ChronoUnit.MINUTES),
+                Arrays.asList(cfg.mSuffix(),cfg.minuteSuffix(),cfg.minutesSuffix()));
+
+        allEqual(Duration.of(10, ChronoUnit.HOURS),
+                Arrays.asList(cfg.hSuffix(),cfg.hourSuffix(),cfg.hoursSuffix()));
+
+        allEqual(Duration.of(10, ChronoUnit.DAYS),
+                Arrays.asList(cfg.dSuffix(),cfg.daySuffix(),cfg.daysSuffix()));
+    }
+
+}

--- a/owner-java8/src/test/java/org/aeonbits/owner/typeconversion/DurationTypesTest.java
+++ b/owner-java8/src/test/java/org/aeonbits/owner/typeconversion/DurationTypesTest.java
@@ -143,6 +143,22 @@ public class DurationTypesTest {
         @ConverterClass(DurationConverter.class)
         @DefaultValue("10 days")
         Duration daysSuffix();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("PT15M")
+        Duration iso8601NoPrefix15Minutes();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("-PT15M")
+        Duration iso8601MinusPrefix15Minutes();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("+PT15M")
+        Duration iso8601PlusPrefix15Minutes();
+
+        @ConverterClass(DurationConverter.class)
+        @DefaultValue("-PT-6H+3M")
+        Duration iso8601Complex();
     }
 
     private static boolean allEqual(Duration compareTo, Collection<Duration> durations){
@@ -190,6 +206,15 @@ public class DurationTypesTest {
 
         allEqual(Duration.of(10, ChronoUnit.DAYS),
                 Arrays.asList(cfg.dSuffix(),cfg.daySuffix(),cfg.daysSuffix()));
+    }
+
+    @Test
+    public void testIso8601() {
+        DurationTypesConfig cfg = ConfigFactory.create(DurationTypesConfig.class);
+        assertEquals(Duration.of(15, ChronoUnit.MINUTES), cfg.iso8601NoPrefix15Minutes());
+        assertEquals(cfg.iso8601NoPrefix15Minutes(), cfg.iso8601PlusPrefix15Minutes());
+        assertEquals(Duration.of(-15, ChronoUnit.MINUTES), cfg.iso8601MinusPrefix15Minutes());
+        assertEquals(Duration.of(6, ChronoUnit.HOURS).minus(3, ChronoUnit.MINUTES), cfg.iso8601Complex());
     }
 
 }


### PR DESCRIPTION
Here is a suggestion for a DurationConverter for what was requested in #155.

This converter is dependent on the java.time package that was introduced in Java 8. I've therefore added the code to the owner-java8 module.

Implementing this with Java5 compatability would not be impossible but it would be much more work.