### PR TITLE
Accept File Paths Containing Spaces.

### DIFF
--- a/owner/src/main/java/org/aeonbits/owner/ConfigURIFactory.java
+++ b/owner/src/main/java/org/aeonbits/owner/ConfigURIFactory.java
@@ -13,6 +13,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 import static org.aeonbits.owner.Util.fixBackslashesToSlashes;
+import static org.aeonbits.owner.Util.fixSpacesToPercentTwenty;
 
 /**
  * @author Luigi R. Viggiano
@@ -20,6 +21,7 @@ import static org.aeonbits.owner.Util.fixBackslashesToSlashes;
 class ConfigURIFactory {
 
     private static final String CLASSPATH_PROTOCOL = "classpath:";
+    private static final String FILE_PROTOCOL = "file:";
     private final transient ClassLoader classLoader;
     private final VariablesExpander expander;
 
@@ -37,6 +39,9 @@ class ConfigURIFactory {
             if (url == null)
                 return null;
             return url.toURI();
+        } else if (fixed.startsWith(FILE_PROTOCOL)) {
+            String path = fixSpacesToPercentTwenty(fixed);
+            return new URI(path);
         } else {
             return new URI(fixed);
         }

--- a/owner/src/main/java/org/aeonbits/owner/Util.java
+++ b/owner/src/main/java/org/aeonbits/owner/Util.java
@@ -108,6 +108,10 @@ abstract class Util {
         return path.replace('\\', '/');
     }
 
+    public static String fixSpacesToPercentTwenty(String path) {
+        return path.replace(" ", "%20");
+    }
+
     static <T> T ignore() {
         // the ignore method does absolutely nothing, but it helps to shut up warnings by pmd and other reporting tools
         // complaining about empty catch methods.

--- a/owner/src/test/java/org/aeonbits/owner/loadstrategies/LoadPathsWithSpacesTest.java
+++ b/owner/src/test/java/org/aeonbits/owner/loadstrategies/LoadPathsWithSpacesTest.java
@@ -1,0 +1,52 @@
+package org.aeonbits.owner.loadstrategies;
+
+import static org.junit.Assert.assertEquals;
+
+import org.aeonbits.owner.Config;
+import org.aeonbits.owner.ConfigFactory;
+import org.aeonbits.owner.LoadersManagerForTest;
+import org.aeonbits.owner.VariablesExpanderForTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Properties;
+import java.util.concurrent.ScheduledExecutorService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LoadPathsWithSpacesTest extends LoadStrategyTestBase {
+
+  @Mock
+  private ScheduledExecutorService scheduler;
+  @Spy
+  private final LoadersManagerForTest loaders = new LoadersManagerForTest();
+  private final VariablesExpanderForTest expander = new VariablesExpanderForTest(new Properties());
+
+
+  @Config.Sources({
+      "file:${user.dir}/src/test/resources/org/aeonbits/owner/directory with spaces/simple.properties"})
+  public static interface FileConfigWithSource extends Config {
+    String helloWorld();
+  }
+
+  @Config.Sources({
+      "classpath:org/aeonbits/owner/directory with spaces/simple.properties"})
+  public static interface ClasspathConfigWithSource extends Config {
+    String helloWorld();
+  }
+
+  @Test
+  public void shouldLoadFromFile() throws Exception {
+    FileConfigWithSource sample = ConfigFactory.create(FileConfigWithSource.class);
+    assertEquals("Hello World!", sample.helloWorld());
+  }
+
+  @Test
+  public void shouldLoadFromClasspath() throws Exception {
+    ClasspathConfigWithSource sample = ConfigFactory.create(ClasspathConfigWithSource.class);
+    assertEquals("Hello World!", sample.helloWorld());
+  }
+
+}

--- a/owner/src/test/resources/org/aeonbits/owner/directory with spaces/simple.properties
+++ b/owner/src/test/resources/org/aeonbits/owner/directory with spaces/simple.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2012-2015, Luigi R. Viggiano
+# All rights reserved.
+#
+# This software is distributable under the BSD license.
+# See the terms of the BSD license in the documentation provided with this software.
+#
+
+helloWorld = Hello World!


### PR DESCRIPTION
Updated the uri processing to allow loading files that contain spaces in
their path names.

Resolves: https://github.com/lviggiano/owner/issues/134