### PR TITLE
First implementation of template support using method parameters

### DIFF
--- a/owner/src/main/java/org/aeonbits/owner/Template.java
+++ b/owner/src/main/java/org/aeonbits/owner/Template.java
@@ -1,0 +1,12 @@
+package org.aeonbits.owner;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Template {
+    String value();
+}

--- a/owner/src/test/java/org/aeonbits/owner/PropertiesInvocationHandlerTest.java
+++ b/owner/src/test/java/org/aeonbits/owner/PropertiesInvocationHandlerTest.java
@@ -17,9 +17,11 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.lang.reflect.Method;
 import java.util.Properties;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 
@@ -56,6 +58,22 @@ public class PropertiesInvocationHandlerTest {
     public void testListPrintWriter() throws Throwable {
         handler.invoke(proxy, MyConfig.class.getDeclaredMethod("list", PrintWriter.class), printWriter);
         verify(properties).list(eq(printWriter));
+    }
+
+    @Test
+    public void format() throws Exception {
+        Method greetingMethod = getClass().getMethod("greeting", String.class, String.class);
+        Object[] args = {"Monday", "Tuesday"};
+        Method formatMethod = handler.getClass()
+                .getMethod("format", Method.class, String.class, Object[].class);
+        String formatted = (String)formatMethod.invoke(handler, greetingMethod,
+                greetingMethod.invoke(this, args), args);
+        assertEquals("Hello from Monday and Tuesday!", formatted);
+    }
+
+    @Template("firstDay, secondDay")
+    public String greeting(String firstDay, String secondDay) {
+        return "Hello from {FIRSTDAY} and {SECONDDAY}!";
     }
 
     public interface MyConfig extends Config, Accessible {


### PR DESCRIPTION
I think the parameter formatting feature shown on page 48 of [Overview](http://www.slideshare.net/LuigiViggiano/owner-31716769) is great!
I don't want you to drop it, because it might be useful in my opinion.
I would like to see it enhanced. In particular, I'd avoid the `String.format()` method, supporting a more specific usage instead.

I'd propose to declare variables like this: `{NAME}`, using the following fallback mechanism:
1. If `@Template` annotation is present, use it to determine names of template variables
2. Otherwise, use formal parameter names as seen in the source code<sup>1</sup>
3. If `-parameters` option was not provided at compile-time, or runtime is above 1.8, compute names as indexes starting since 1, and increasing by 1 for each parameter

There is however a problem I can't cope with: to fetch parameter names, one trying to avoid third-party libraries has to use a Java 8+ API in order to do this. How can one skip this step, if the language level doesn't allow it? Check out TODOs.

<sup>1</sup> I particularly like this one.