### PR TITLE
Adding the ability to register default converters for types.

### DIFF
--- a/owner/src/main/java/org/aeonbits/owner/ConfigFactory.java
+++ b/owner/src/main/java/org/aeonbits/owner/ConfigFactory.java
@@ -134,4 +134,24 @@ public final class ConfigFactory {
         INSTANCE.registerLoader(loader);
     }
 
+    /**
+     * Sets a converter for the given type. Setting a converter via this method will override any default converters
+     * but not {@link Config.ConverterClass} annotations.
+     *
+     * @param type the type for which to set a converter.
+     * @param converter the converter class to use for the specified type.
+     * @since 1.0.10
+     */
+    public static void setTypeConverter(Class<?> type, Class<? extends Converter<?>> converter) {
+        INSTANCE.setTypeConverter(type, converter);
+    }
+
+    /**
+     * Removes a converter for the given type.
+     * @param type the type for which to remove the converter.
+     * @since 1.0.10
+     */
+    public static void removeTypeConverter(Class<?> type){
+        INSTANCE.removeTypeConverter(type);
+    }
 }

--- a/owner/src/main/java/org/aeonbits/owner/DefaultFactory.java
+++ b/owner/src/main/java/org/aeonbits/owner/DefaultFactory.java
@@ -76,6 +76,14 @@ class DefaultFactory implements Factory {
         loadersManager.registerLoader(loader);
     }
 
+    public void setTypeConverter(Class<?> type, Class<? extends Converter<?>> converter) {
+        Converters.setTypeConverter(type, converter);
+    }
+
+    public void removeTypeConverter(Class<?> type){
+        Converters.removeTypeConverter(type);
+    }
+
     public String getProperty(String key) {
         checkKey(key);
         return props.getProperty(key);

--- a/owner/src/main/java/org/aeonbits/owner/Factory.java
+++ b/owner/src/main/java/org/aeonbits/owner/Factory.java
@@ -88,4 +88,20 @@ public interface Factory {
      */
     void registerLoader(Loader loader);
 
+    /**
+     * Sets a converter for the given type. Setting a converter via this method will override any default converters
+     * but not {@link Config.ConverterClass} annotations.
+     *
+     * @param type the type for which to set a converter.
+     * @param converter the converter class to use for the specified type.
+     * @since 1.0.10
+     */
+    void setTypeConverter(Class<?> type, Class<? extends Converter<?>> converter);
+
+    /**
+     * Removes a converter for the given type.
+     * @param type the type for which to remove the converter.
+     * @since 1.0.10
+     */
+    void removeTypeConverter(Class<?> type);
 }

--- a/owner/src/test/java/org/aeonbits/owner/typeconversion/ConverterRegistryTest.java
+++ b/owner/src/test/java/org/aeonbits/owner/typeconversion/ConverterRegistryTest.java
@@ -1,0 +1,76 @@
+package org.aeonbits.owner.typeconversion;
+
+import org.aeonbits.owner.Config;
+import org.aeonbits.owner.ConfigFactory;
+import org.aeonbits.owner.Converter;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by stefan on 7.9.2016.
+ */
+public class ConverterRegistryTest {
+    private static final String LEET_SPEEK = "1'm 50 l337";
+    private static final String LEET_TRANSLATION = "I'm so leet";
+    private static final String FOOBAR_RESPONSE = "FooBar";
+
+    public static class LeetTranslatorConverter implements Converter<String> {
+        Map<Character,Character> lookup = new HashMap<Character, Character>();
+        public LeetTranslatorConverter(){
+            lookup.put('1', 'I');
+            lookup.put('5', 's');
+            lookup.put('0', 'o');
+            lookup.put('3', 'e');
+            lookup.put('7', 't');
+        }
+
+        public String convert(Method targetMethod, String text) {
+            StringBuilder sb = new StringBuilder(text);
+            for( int i=0 ; i<text.length(); i++) {
+                if( lookup.containsKey(text.charAt(i))){
+                    sb.setCharAt(i, lookup.get(text.charAt(i)));
+                }
+            }
+            return sb.toString();
+        }
+    }
+
+    public static class FooBarConverter implements Converter<String> {
+        public String convert(Method method, String input) {
+            return FOOBAR_RESPONSE;
+        }
+    }
+
+        interface MyConfig extends Config {
+        @DefaultValue(LEET_SPEEK)
+        String leetSpeek();
+
+        @DefaultValue(LEET_SPEEK)
+        @ConverterClass(FooBarConverter.class)
+        String leetSpeekWithConverterClassAnnotation();
+    }
+
+    @Test
+    public void testBasicConverterRegistry(){
+        MyConfig cfg = ConfigFactory.create(MyConfig.class);
+        assertEquals("Converter class has not been registered yet.", LEET_SPEEK, cfg.leetSpeek());
+        ConfigFactory.setTypeConverter(String.class, LeetTranslatorConverter.class);
+        assertEquals("Registered converter class should have been used but wasn't.", LEET_TRANSLATION, cfg.leetSpeek());
+        ConfigFactory.removeTypeConverter(String.class);
+        assertEquals("Converter class should have been removed.", LEET_SPEEK, cfg.leetSpeek());
+    }
+
+    @Test
+    public void testConverterClassAnnotationOverride(){
+        MyConfig cfg = ConfigFactory.create(MyConfig.class);
+        assertEquals("Expected a response from the annotated converter class", FOOBAR_RESPONSE, cfg.leetSpeekWithConverterClassAnnotation());
+        ConfigFactory.setTypeConverter(String.class, LeetTranslatorConverter.class);
+        assertEquals("Still expecting a response from the annotated converter class", FOOBAR_RESPONSE, cfg.leetSpeekWithConverterClassAnnotation());
+        ConfigFactory.removeTypeConverter(String.class);
+    }
+}

--- a/owner/src/test/java/org/aeonbits/owner/typeconversion/ConverterRegistryTest.java
+++ b/owner/src/test/java/org/aeonbits/owner/typeconversion/ConverterRegistryTest.java
@@ -46,7 +46,7 @@ public class ConverterRegistryTest {
         }
     }
 
-        interface MyConfig extends Config {
+    interface MyConfig extends Config {
         @DefaultValue(LEET_SPEEK)
         String leetSpeek();
 

--- a/owner/src/test/java/org/aeonbits/owner/typeconversion/ConverterRegistryTest.java
+++ b/owner/src/test/java/org/aeonbits/owner/typeconversion/ConverterRegistryTest.java
@@ -68,7 +68,7 @@ public class ConverterRegistryTest {
     @Test
     public void testConverterClassAnnotationOverride(){
         MyConfig cfg = ConfigFactory.create(MyConfig.class);
-        assertEquals("Expected a response from the annotated converter class", FOOBAR_RESPONSE, cfg.leetSpeekWithConverterClassAnnotation());
+        assertEquals("Expected a response from the annotated converter class.", FOOBAR_RESPONSE, cfg.leetSpeekWithConverterClassAnnotation());
         ConfigFactory.setTypeConverter(String.class, LeetTranslatorConverter.class);
         assertEquals("Still expecting a response from the annotated converter class", FOOBAR_RESPONSE, cfg.leetSpeekWithConverterClassAnnotation());
         ConfigFactory.removeTypeConverter(String.class);


### PR DESCRIPTION
This pull request fixes issue #155 by adding the ability to set a converter class for a given return type.

I'm mainly creating this PR to get feedback and see if @lviggiano is okay with the approach I'm taking or whether he has other ideas on how to implement this.

If things look good I'll add some more unit tests (although suggestions on what else to test would be appreciated) and documentation for this feature.
