### PR TITLE
Fix for #184 - have ConfigFactory throw exeption on illegal import maps

### DIFF
--- a/owner/src/main/java/org/aeonbits/owner/ConfigFactory.java
+++ b/owner/src/main/java/org/aeonbits/owner/ConfigFactory.java
@@ -63,6 +63,13 @@ public final class ConfigFactory {
      * @return an object implementing the given interface, which maps methods to property values.
      */
     public static <T extends Config> T create(Class<? extends T> clazz, Map<?, ?>... imports) {
+        for( Map<?, ?> map : imports ){
+            for( Object key : map.keySet() ){
+                if( key == null || map.get(key) == null){
+                    throw new IllegalArgumentException(String.format("An import contains a null value for key: %s", key));
+                }
+            }
+        }
         return INSTANCE.create(clazz, imports);
     }
 

--- a/owner/src/main/java/org/aeonbits/owner/ConfigFactory.java
+++ b/owner/src/main/java/org/aeonbits/owner/ConfigFactory.java
@@ -66,7 +66,7 @@ public final class ConfigFactory {
         for( Map<?, ?> map : imports ){
             for( Object key : map.keySet() ){
                 if( key == null || map.get(key) == null){
-                    throw new IllegalArgumentException(String.format("An import contains a null value for key: %s", key));
+                    throw new IllegalArgumentException(String.format("An import contains a null value for key: '%s'", key));
                 }
             }
         }

--- a/owner/src/test/java/org/aeonbits/owner/issues/Issue184.java
+++ b/owner/src/test/java/org/aeonbits/owner/issues/Issue184.java
@@ -1,0 +1,47 @@
+package org.aeonbits.owner.issues;
+
+import org.aeonbits.owner.Config;
+import org.aeonbits.owner.ConfigFactory;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue184 {
+
+    private static final String KEY = "null.value.key";
+
+    public interface MyConfig extends Config {
+        @Key(KEY)
+        @DefaultValue("1")
+        Integer getNullValueKey();
+    }
+
+    @Test
+    public void testConfigImportWithNullValue() throws Exception {
+        Map<String,String> propsMapWithNullValue = new HashMap<String,String>();
+        propsMapWithNullValue.put("null.value.key", null);
+
+        try {
+            ConfigFactory.create(Issue184.MyConfig.class, propsMapWithNullValue);
+        }
+        catch(IllegalArgumentException e){
+            assertTrue(e.getMessage().contains(KEY));
+        }
+    }
+
+    @Test
+    public void testConfigImportWithNullKey() throws Exception {
+        Map<String,String> propsMapWithNullValue = new HashMap<String,String>();
+        propsMapWithNullValue.put(null, "smurf");
+
+        try {
+            ConfigFactory.create(Issue184.MyConfig.class, propsMapWithNullValue);
+        }
+        catch(IllegalArgumentException e){
+            assertTrue(e.getMessage().contains("null"));
+        }
+    }
+}


### PR DESCRIPTION
This PR will ensure that ConfigFactory throws an exception with a message containing the problematic key name if an import map contains either a null key or a null value.

OWNER currently fails when an import map contains a null key or value, this PR simply makes the error message clearer.
