### PR TITLE
Add inheritance support for Sources, LoadPolicy and HotReload

### DIFF
--- a/owner/src/main/java/org/aeonbits/owner/PropertiesManager.java
+++ b/owner/src/main/java/org/aeonbits/owner/PropertiesManager.java
@@ -44,6 +44,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 
+import static java.util.Collections.emptyIterator;
 import static java.util.Collections.synchronizedList;
 import static org.aeonbits.owner.Config.LoadType.FIRST;
 import static org.aeonbits.owner.PropertiesMapper.defaults;
@@ -104,10 +105,30 @@ class PropertiesManager implements Reloadable, Accessible, Mutable {
         ConfigURIFactory urlFactory = new ConfigURIFactory(clazz.getClassLoader(), expander);
         uris = toURIs(clazz.getAnnotation(Sources.class), urlFactory);
 
+        for (Class<?> inter: clazz.getInterfaces()){
+            this.uris.addAll(toURIs(inter.getAnnotation(Sources.class),urlFactory));
+        }
+
         LoadPolicy loadPolicy = clazz.getAnnotation(LoadPolicy.class);
+        if (loadPolicy==null) {
+            for (Class<?> inter : clazz.getInterfaces()) {
+                loadPolicy = inter.getAnnotation(LoadPolicy.class);
+                if (loadPolicy != null){
+                    break;
+                }
+            }
+        }
         loadType = (loadPolicy != null) ? loadPolicy.value() : FIRST;
 
         HotReload hotReload = clazz.getAnnotation(HotReload.class);
+        if (hotReload == null){
+            for (Class<?> inter : clazz.getInterfaces()) {
+                hotReload = inter.getAnnotation(HotReload.class);
+                if (hotReload != null){
+                    break;
+                }
+            }
+        }
         if (hotReload != null) {
             hotReloadLogic = new HotReloadLogic(hotReload, uris, this);
 

--- a/owner/src/main/java/org/aeonbits/owner/PropertiesManager.java
+++ b/owner/src/main/java/org/aeonbits/owner/PropertiesManager.java
@@ -44,7 +44,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
 
-import static java.util.Collections.emptyIterator;
 import static java.util.Collections.synchronizedList;
 import static org.aeonbits.owner.Config.LoadType.FIRST;
 import static org.aeonbits.owner.PropertiesMapper.defaults;

--- a/owner/src/test/java/org/aeonbits/owner/ConfigInheritanceTest.java
+++ b/owner/src/test/java/org/aeonbits/owner/ConfigInheritanceTest.java
@@ -1,0 +1,50 @@
+package org.aeonbits.owner;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+/**
+ * Created by chengmingwang on 12/24/16.
+ */
+public class ConfigInheritanceTest {
+    @Config.Sources(
+            {"classpath:test.properties","classpath:org/aeonbits/owner/first.properties"}
+    )
+    interface MyConfig extends Config {
+        @DefaultValue("favoriteColor")
+        String favoriteColor();
+    }
+
+    interface TheConfig1 extends MyConfig {
+
+    }
+
+    @Config.Sources(
+            {"classpath:org/aeonbits/owner/second.properties"}
+    )
+    interface TheConfig2 extends MyConfig {
+
+    }
+
+    @Config.Sources(
+            {"classpath:org/aeonbits/owner/second.properties"}
+    )
+    @Config.LoadPolicy(Config.LoadType.MERGE)
+    interface TheConfig3 extends MyConfig {
+
+    }
+
+    @Test
+    public void testSourcesInheritance() {
+        TheConfig1 theConfig1 = ConfigFactory.create(TheConfig1.class);
+        assertEquals("pink", theConfig1.favoriteColor());
+
+        TheConfig2 theConfig2 = ConfigFactory.create(TheConfig2.class);
+        assertEquals("favoriteColor", theConfig2.favoriteColor());
+
+        TheConfig3 theConfig3 = ConfigFactory.create(TheConfig3.class);
+        assertEquals("pink", theConfig3.favoriteColor());
+    }
+}


### PR DESCRIPTION
I found inheritance support for Sources, LoadPolicy and HotReload would be very helpful for my project, sources can be defined in one place and used everywhere. Following are my changes:

1. Sources defined for all extended interfaces will be merged.
2. LoadPolicy and HotReload can be inherited and override by the extended interface.