### PR TITLE
Fix for #192 - Replace fixBackslashForRegex call 

### DIFF
--- a/owner/src/main/java/org/aeonbits/owner/StrSubstitutor.java
+++ b/owner/src/main/java/org/aeonbits/owner/StrSubstitutor.java
@@ -77,7 +77,7 @@ class StrSubstitutor implements Serializable {
             String var = m.group(1);
             String value = values.getProperty(var);
             String replacement = (value != null) ? replace(value) : "";
-            m.appendReplacement(sb, fixBackslashForRegex(replacement));
+            m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
         }
         m.appendTail(sb);
         return sb.toString();

--- a/owner/src/main/java/org/aeonbits/owner/Util.java
+++ b/owner/src/main/java/org/aeonbits/owner/Util.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.jar.JarOutputStream;
+import java.util.regex.Matcher;
 import java.util.zip.ZipEntry;
 
 import static java.io.File.createTempFile;
@@ -94,9 +95,9 @@ abstract class Util {
         if (text.equals("~"))
             return system.getProperty("user.home");
         if (text.indexOf("~/") == 0 || text.indexOf("file:~/") == 0 || text.indexOf("jar:file:~/") == 0)
-            return text.replaceFirst("~/", fixBackslashForRegex(system.getProperty("user.home")) + "/");
+            return text.replaceFirst("~/", Matcher.quoteReplacement(system.getProperty("user.home")) + "/");
         if (text.indexOf("~\\") == 0 || text.indexOf("file:~\\") == 0 || text.indexOf("jar:file:~\\") == 0)
-            return text.replaceFirst("~\\\\", fixBackslashForRegex(system.getProperty("user.home")) + "\\\\");
+            return text.replaceFirst("~\\\\", Matcher.quoteReplacement(system.getProperty("user.home")) + "\\\\");
         return text;
     }
 


### PR DESCRIPTION
This is a pull request to solve the probem that I have described in Issue #192: java.lang.IllegalArgumentException: Illegal group reference.
I got this error also after downloading version 1.0.9 on my local machine and starting mvn test.
Why? Because the home directory (which points to a server) contains a $ in our company.

The fixBackslashForRegedit only cares about backslashes. If the string contains a $ sign the matcher produces an error. 
The Matcher.quoteReplacement also cares about the $ sign. So the errors does not appear anymore.mvn 

After the update all test run without error.
