### PR TITLE
Set tar long file mode to posix in maven assembly plugin to avoid build error

### DIFF
--- a/owner-assembly/pom.xml
+++ b/owner-assembly/pom.xml
@@ -46,6 +46,7 @@
                     <descriptors>
                         <descriptor>src/main/assemblies/bin.xml</descriptor>
                     </descriptors>
+                    <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
I got the following error while attempting to build the latest owner source:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:3.1.0:single (default) on project owner-assembly: Execution default of goal org.apache.maven.plugins:maven-assembly-plugin:3.1.0:single failed: group id '1364459042' is too big ( > 2097151 ). Use STAR or POSIX extensions to overcome this limit -> [Help 1]
```

Added configuration value to owner-assembly/pom.xml to set tar long file mode to posix to correct this error, as per FAQ: https://maven.apache.org/plugins/maven-assembly-plugin/faq.html#tarFileModes