### PR TITLE
Updated apache-curator dependency

### DIFF
--- a/owner-extras/pom.xml
+++ b/owner-extras/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
-            <version>2.6.0</version>
+            <version>2.12.0</version>
             <optional>true</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
The version of apache-curator 2.6.0 used in the extras submodule comes with several vulnerabilities, upgrading to 2.12.0 solves these problems:

- https://issues.apache.org/jira/browse/CURATOR-358
- https://issues.apache.org/jira/browse/CURATOR-335
- https://issues.apache.org/jira/browse/CURATOR-286
- https://issues.apache.org/jira/browse/CURATOR-240
- https://issues.apache.org/jira/browse/CURATOR-209
- http://cve.mitre.org/cgi-bin/cvename.cgi?name=2017-5637 (from zookeper, transitive from curator) 

We strongly suggest to apply this patch.
https://meterian.io
