### PR TITLE
Allowing to format Key value by method arguments as with DefaultValue

### DIFF
--- a/owner/src/main/java/org/aeonbits/owner/PropertiesInvocationHandler.java
+++ b/owner/src/main/java/org/aeonbits/owner/PropertiesInvocationHandler.java
@@ -75,7 +75,7 @@ class PropertiesInvocationHandler implements InvocationHandler, Serializable {
     }
 
     private Object resolveProperty(Method method, Object... args) {
-        String key = expandKey(method);
+        String key = expandKey(method, args);
         String value = propertiesManager.getProperty(key);
 
         // TODO: this if should go away! See #84 and #86
@@ -102,11 +102,11 @@ class PropertiesInvocationHandler implements InvocationHandler, Serializable {
         return result;
     }
 
-    private String expandKey(Method method) {
+    private String expandKey(Method method, Object... args) {
         String key = key(method);
         if (isFeatureDisabled(method, VARIABLE_EXPANSION))
             return key;
-        return substitutor.replace(key);
+        return substitutor.replace(key, args);
     }
 
     private String format(Method method, String format, Object... args) {

--- a/owner/src/main/java/org/aeonbits/owner/StrSubstitutor.java
+++ b/owner/src/main/java/org/aeonbits/owner/StrSubstitutor.java
@@ -82,4 +82,20 @@ class StrSubstitutor implements Serializable {
         return sb.toString();
     }
 
+    /**
+     * Returns a string modified in according to supplied source and arguments.<br/>
+     * If the source string has pattern-replacement content like {@code "a.${var}.b"},
+     * the pattern is replaced property value of "var".<br/>
+     * Otherwise the return string is formatted by source and arguments as with {@link String#format(String, Object...)}
+     *
+     * @param source A source formatting format string. {@code null} returns {@code null}
+     * @param args Arguments referenced by the format specifiers in the source string.
+     * @return formatted string
+     */
+    String replace(String source, Object... args) {
+        if (source == null)
+            return null;
+        Matcher m = PATTERN.matcher(source);
+        return m.find() ? replace(source) : String.format(source, args);
+    }
 }

--- a/owner/src/test/java/org/aeonbits/owner/StrSubstitutorTest.java
+++ b/owner/src/test/java/org/aeonbits/owner/StrSubstitutorTest.java
@@ -93,4 +93,16 @@ public class StrSubstitutorTest {
         assertEquals(expected, result);
     }
 
+    @Test
+    public void testParametrization() {
+        Properties values = new Properties() {{
+            setProperty("foo", "fooValue");
+            setProperty("baz", "bazValue");
+        }};
+
+        StrSubstitutor sub = new StrSubstitutor(values);
+        assertEquals("foo1", sub.replace("foo%d", 1));
+        assertEquals("baz", sub.replace("baz"));
+        assertEquals("foo.1.sfx", sub.replace("foo.%d.%s", 1, "sfx"));
+    }
 }

--- a/owner/src/test/java/org/aeonbits/owner/variableexpansion/ParametrizedKeyTest.java
+++ b/owner/src/test/java/org/aeonbits/owner/variableexpansion/ParametrizedKeyTest.java
@@ -1,0 +1,54 @@
+package org.aeonbits.owner.variableexpansion;
+
+import static org.aeonbits.owner.Config.DisableableFeature.VARIABLE_EXPANSION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.aeonbits.owner.Config;
+import org.aeonbits.owner.ConfigFactory;
+import org.junit.Test;
+
+/**
+ * @author aknopov
+ */
+public class ParametrizedKeyTest
+{
+    private static final String DEV_SETUP = "dev";
+    private static final String UAT_SETUP = "uat";
+
+    @Config.Sources("classpath:org/aeonbits/owner/variableexpansion/KeyExpansionExample.xml")
+    public interface MyConfig extends Config {
+        @Key("servers.%s.name")
+        String name(String setup);
+
+        @Key("servers.%s.hostname")
+        String hostname(String setup);
+
+        @Key("servers.%s.port")
+        Integer port(String setup);
+
+        @Key("servers.%s.user")
+        String user(String setup);
+
+        @DisableFeature(VARIABLE_EXPANSION)
+        @Key("servers.%s.password")
+        String password(String setup);
+    }
+
+    @Test
+    public void testKeyParametrization() {
+        MyConfig cfg = ConfigFactory.create(MyConfig.class);
+
+        assertEquals("DEV", cfg.name(DEV_SETUP));
+        assertEquals("devhost", cfg.hostname(DEV_SETUP));
+        assertEquals(new Integer(6000), cfg.port(DEV_SETUP));
+        assertEquals("myuser1", cfg.user(DEV_SETUP));
+        assertNull(cfg.password(DEV_SETUP)); // expansion is disabled on method level
+
+        assertEquals("UAT", cfg.name(UAT_SETUP));
+        assertEquals("uathost", cfg.hostname(UAT_SETUP));
+        assertEquals(new Integer(60020), cfg.port(UAT_SETUP));
+        assertEquals("myuser2", cfg.user(UAT_SETUP));
+        assertNull(cfg.password(UAT_SETUP)); // expansion is disabled on method level
+    }
+}


### PR DESCRIPTION
Hi Luigi, I decided to accelerate a bit my request for parametrizing keys :).

I have to acknowledge that one existing test SyncAutoReloadTest.testAutoReload() fails because "SyncAutoReloadConfig.properties" is not extracted from SyncAutoReloadTest.jar (though I use Gradle for build).
I also mentioned that SystemLoaderTest.merge_pathEnvVariable() fails in Windows (it uses "Path", not "PATH")

Here are the changes
- Refactored PropertiesInvocationHandler - passing arguments to StrSubstitutor.replace()
- Allowing either variable expansion or String formatting in StrSubstitutor
- Added specialized unit test