### PR TITLE
Allow property values to contain a '%' character without being a format string

### DIFF
--- a/owner/src/main/java/org/aeonbits/owner/PropertiesInvocationHandler.java
+++ b/owner/src/main/java/org/aeonbits/owner/PropertiesInvocationHandler.java
@@ -112,7 +112,24 @@ class PropertiesInvocationHandler implements InvocationHandler, Serializable {
     private String format(Method method, String format, Object... args) {
         if (isFeatureDisabled(method, PARAMETER_FORMATTING))
             return format;
-        return String.format(format, args);
+
+        // If there are no arguments to format, we can just return.
+        // This is also helpful when the {@code format} is a property value that contains a '%' character,
+        // such as '@#$%^&*()" (e.g., a clear-text password). In such cases, the '%' character is not
+        // a placeholder in a format string -- its just a random character in the property value.
+        if ( args == null || args.length == 0 )
+            return format;
+
+        try {
+            // Do this to achieve property expansion
+            return String.format(format, args);
+            }
+        catch ( Exception e ) {
+            // There's no guarantee that a property value from a config file
+            // is a legal format string. When formatting doesn't work, let's
+            // just return the original property value.
+            return format;
+            }
     }
 
     private String expandVariables(Method method, String value) {

--- a/owner/src/test/java/org/aeonbits/owner/ConfigTest.java
+++ b/owner/src/test/java/org/aeonbits/owner/ConfigTest.java
@@ -44,6 +44,10 @@ public class ConfigTest {
         @DefaultValue("Good Morning")
         String salutation();
 
+        @Key("password")
+        @DefaultValue("@#$%^&*()")
+        String password();
+
         @DefaultValue("foo")
         void voidMethodWithValue();
 
@@ -122,6 +126,19 @@ public class ConfigTest {
         SubstituteAndFormat cfg = ConfigFactory.create(SubstituteAndFormat.class);
         assertEquals("Hello Mr. Luigi", cfg.salutation("Luigi"));
         assertEquals("Mr. Luigi", cfg.mister("Luigi"));
+    }
+
+    /**
+     * When a property value contains a '%' character but is not a String format,
+     * we expect the property value to be returned as-is. Under the covers, the String.format
+     * method is used for property expansion. We want to verify a property value that
+     * contains a '%' character but is _not_ a format String is, indeed, supported.
+     */
+    @Test
+    public void whenPropertyValueIsNotValidFormatString_thenPropertyValueShouldRemainIntact() {
+        SampleConfig config = ConfigFactory.create(SampleConfig.class);
+
+        assertEquals ("@#$%^&*()", config.password());
     }
 
 }


### PR DESCRIPTION
When a property value contains a '%' character, it can be mistaken for a format string (under the covers, String.format is called to expand property values).  With this fix, if a property value contains a '%' character but is not actually a format string, we return the property value as-is. 