### PR TITLE
Documentation for system:properties and system:env

### DIFF
--- a/owner-site/site/docs/loading-strategies.md
+++ b/owner-site/site/docs/loading-strategies.md
@@ -58,7 +58,9 @@ the annotation `@LoadPolicy(LoadType.MERGE)`:
 @LoadPolicy(LoadType.MERGE)
 @Sources({ "file:~/.myapp.config", 
            "file:/etc/myapp.config", 
-           "classpath:foo/bar/baz.properties" })
+           "classpath:foo/bar/baz.properties",
+           "system:properties",
+           "system:env" })
 public interface ServerConfig extends Config {
     ...
 }
@@ -72,9 +74,13 @@ More in detail, this is what will happen:
     if the given property is found the associated value will be returned.
  2. Then it will try to load the given property from /etc/myapp.config;
     if the property is found the value associated will be returned.
- 3. As last resort it will try to load the given property from the classpath from the resource identified
+ 3. Then it will try to load the given property from the classpath from the resource identified
     by the path foo/bar/baz.properties; if the property is found, the associated value is returned.
- 4. If the given property is not found of any of the above cases, it will be returned the value specified by the
+ 4. Otherwise, it will try to load the given property from the <a  href="https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html">Java system properties</a>;
+ if such property is defined, the associated value is returned.
+ 5. As last resort, it will try to load the given property from the <a    href="https://docs.oracle.com/javase/tutorial/essential/environment/env.html">operating system's environment variables</a>;
+ if an environment variable with the same name is found, its value will be returned.    
+ 6. If the given property is not found of any of the above cases, it will be returned the value specified by the
     `@DefaultValue` if specified, otherwise null will be returned.
 
 So basically we produce a merge between the properties files where the first property files overrides latter ones.


### PR DESCRIPTION
I have updated the documentation with information about the system:properties and system:env pseudo-urls. The are added to the example of loading-strategies.md; and the examples of importing-properties.md have been reworked to avoid recommending the use of that mechanism for Java or environment properties. (That said, the second example maybe is not the best choice, but I could not come up with any other usage of importing properties which was more realistic).